### PR TITLE
Provide uninstall steps in profile

### DIFF
--- a/src/collective/privacy/profiles/uninstall/componentregistry.xml
+++ b/src/collective/privacy/profiles/uninstall/componentregistry.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<componentregistry>
+  <utilities>
+    <utility
+      remove="True"
+      interface="collective.privacy.interfaces.IPrivacyTool"
+      object="portal_privacy"/>
+  </utilities>
+</componentregistry>

--- a/src/collective/privacy/profiles/uninstall/registry.xml
+++ b/src/collective/privacy/profiles/uninstall/registry.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<registry>
+  <record name="collective.privacy.trust_member_emails" remove="True">
+  </record>
+  <record name="collective.privacy.solicit_consent" remove="True">
+  </record>
+</registry>

--- a/src/collective/privacy/profiles/uninstall/toolset.xml
+++ b/src/collective/privacy/profiles/uninstall/toolset.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<tool-setup>
+ <forbidden tool_id="portal_privacy"
+
+           class="collective.privacy.tool.PrivacyTool"/>
+</tool-setup>

--- a/src/collective/privacy/tests/test_setup.py
+++ b/src/collective/privacy/tests/test_setup.py
@@ -4,6 +4,8 @@ from collective.privacy.testing import COLLECTIVE_PRIVACY_INTEGRATION_TESTING  #
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
 
 import unittest
 
@@ -58,3 +60,14 @@ class TestUninstall(unittest.TestCase):
         self.assertNotIn(
             ICollectivePrivacyLayer,
             utils.registered_layers())
+
+    def test_configuration_registry_removed(self):
+        """ Test that registry keys added to the configuration registry
+            are removed."""
+        registry = getUtility(IRegistry)
+        self.assertNotIn('collective.privacy.trust_member_emails', registry)
+        self.assertNotIn('collective.privacy.solicit_consent', registry)
+
+    def test_privacy_tool_not_in_site_root(self):
+        """ Test that the privacy tool is uninstalled """
+        self.assertNotIn('privacy_tool', self.portal)


### PR DESCRIPTION
When testing the addon I found that it's impossible to uninstall it correctly with the provided uninstall profile, because it lacks to remove the component registry configuration and the tool.

So I added this unregistration to the uninstall profile to uninstall the addon cleanly.