### PR TITLE
Fixes #18 by defering execution of consent.js

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.1.0b2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Defer the execution of consent.js (#18).
+  [comwes]
 
 
 1.1.0b1 (2021-08-19)

--- a/src/collective/privacy/browser/templates/consent_banner.pt
+++ b/src/collective/privacy/browser/templates/consent_banner.pt
@@ -27,6 +27,6 @@
            tal:attributes="href string:${navigation_root_url}/@@consent"
            i18n:translate="">Manage privacy settings</a>
     </div>
-    <script type="text/javascript"
+    <script type="text/javascript" defer="defer"
             tal:attributes="src string:${portal_url}/++resource++collective.privacy/consent.js"></script>
 </div>


### PR DESCRIPTION
In the way, we make sure it is executed after jQuery has been fully loaded